### PR TITLE
Update bright.mplstyle to match Paul Tol's order

### DIFF
--- a/styles/color/bright.mplstyle
+++ b/styles/color/bright.mplstyle
@@ -3,4 +3,4 @@
 # from Paul Tot's website: https://personal.sron.nl/~pault/
 
 # Set color cycle
-axes.prop_cycle : cycler('color', ['4477AA', '66CCEE', '228833', 'CCBB44', 'EE6677', 'AA3377', 'BBBBBB'])
+axes.prop_cycle : cycler('color', ['4477AA', 'EE6677', '228833', 'CCBB44', '66CCEE', 'AA3377', 'BBBBBB'])


### PR DESCRIPTION
From Paul Tol's web site, he proposed this order for the "bright" style.  I looked it up because I didn't like the blue and the cyan next to each other.