### PR TITLE
fix a LaTeX equation problem in the  plot-examples.py

### DIFF
--- a/examples/plot-examples.py
+++ b/examples/plot-examples.py
@@ -8,7 +8,7 @@ def model(x, p):
     return x ** (2 * p + 1) / (1 + x ** (2 * p))
 
 
-pparam = dict(xlabel='Voltage (mV)', ylabel='Current ($\mu$A)')
+pparam = dict(xlabel='Voltage (mV)', ylabel=r'Current ($\mu$A)')
 
 x = np.linspace(0.75, 1.25, 201)
 


### PR DESCRIPTION
The string containing the LaTeX equation should be a raw string, since it may contain a blackslash `\`.

If the following line

```python
pparam = dict(xlabel='Voltage (mV)', ylabel='Current ($\mu$A)')
```
is changed to 

```python
pparam = dict(xlabel='Voltage (mV)', ylabel='Current ($\beta$A)')
```
there will be an error.