### PR TITLE
improve: register self with `__file__`

### DIFF
--- a/scienceplots/__init__.py
+++ b/scienceplots/__init__.py
@@ -2,7 +2,7 @@ import os  # pathlib.Path.walk not available in Python <3.12
 import matplotlib.pyplot as plt
 
 # register the bundled stylesheets in the matplotlib style library
-styles_path = os.path.join(__file__, 'styles')
+styles_path = os.path.join(os.path.dirname(__file__), 'styles')
 
 # Reads styles in /styles folder and all subfolders
 stylesheets = {}  # plt.style.library is a dictionary

--- a/scienceplots/__init__.py
+++ b/scienceplots/__init__.py
@@ -1,11 +1,8 @@
 import os  # pathlib.Path.walk not available in Python <3.12
 import matplotlib.pyplot as plt
 
-import scienceplots
-
 # register the bundled stylesheets in the matplotlib style library
-scienceplots_path = scienceplots.__path__[0]
-styles_path = os.path.join(scienceplots_path, 'styles')
+styles_path = os.path.join(__file__, 'styles')
 
 # Reads styles in /styles folder and all subfolders
 stylesheets = {}  # plt.style.library is a dictionary


### PR DESCRIPTION
replace parsing path from import and rather use `__file__` which is widely supported and more robust reference with respect to various installing styles as for example `pip install -e .`

cc: @garrettj403 @echedey-ls 