### PR TITLE
Fix CJK font styles

### DIFF
--- a/scienceplots/styles/languages/cjk-kr-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-kr-font.mplstyle
@@ -1,5 +1,5 @@
 # Add fonts for CJK characters (Korean)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK KR
+font.serif : Noto Serif CJK JP
 font.family : serif

--- a/scienceplots/styles/languages/cjk-sc-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-sc-font.mplstyle
@@ -1,5 +1,5 @@
 # Add fonts for CJK characters (simplified Chinese)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK SC
+font.serif : Noto Serif CJK JP
 font.family : serif

--- a/scienceplots/styles/languages/cjk-tc-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-tc-font.mplstyle
@@ -1,5 +1,6 @@
 # Add fonts for CJK characters (traditional Chinese)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK TC
+font.serif : Noto Serif CJK JP
 font.family : serif
+


### PR DESCRIPTION
#84 and fix according to [solution](https://github.com/garrettj403/SciencePlots/issues/84#issuecomment-2357455412).

> Just use Noto Serif CJK JP or Noto Sans CJK JP is enough to draw SC/TC/KR Glyph.
