### PR TITLE
Fixes, tests, and config improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ dependencies = ["matplotlib"]
 
 [project.optional-dependencies]
 test = ["pytest", "numpy"]
-all = ["SciencePlots[test]"]
+dev = [
+    "SciencePlots[test]",
+    "ruff"
+]
+all = ["SciencePlots[dev]"]
 
 [project.urls]
 Homepage = "https://github.com/garrettj403/SciencePlots/wiki"
@@ -44,7 +48,9 @@ Issues = "https://github.com/garrettj403/SciencePlots/issues"
 Changelog = "https://github.com/garrettj403/SciencePlots/blob/master/CHANGES.md"
 
 [tool.setuptools_scm]
-# blank section to avoid warning
+# This section enables setuptools_scm to dynamically determine the version
+# from Git tags. Leaving it empty uses default configuration.
+# The project's version is declared as dynamic in the [project] table.
 
 [tool.pytest.ini_options]
 addopts = "-ra"
@@ -56,4 +62,4 @@ line-length = 88
 indent-width = 4
 
 # Exclude annotations and type comments
-lint.ignore = ["ANN"]
+# lint.ignore = ["ANN"]  # Allow Ruff to check for type annotations

--- a/scienceplots/styles/languages/cjk-jp-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-jp-font.mplstyle
@@ -1,5 +1,5 @@
 # Add fonts for CJK characters (Japanese)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK JP
+font.serif : Noto Serif JP
 font.family : serif

--- a/scienceplots/styles/languages/cjk-kr-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-kr-font.mplstyle
@@ -1,5 +1,5 @@
 # Add fonts for CJK characters (Korean)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK KR
+font.serif : Noto Serif KR
 font.family : serif

--- a/scienceplots/styles/languages/cjk-sc-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-sc-font.mplstyle
@@ -1,5 +1,5 @@
 # Add fonts for CJK characters (simplified Chinese)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK SC
+font.serif : Noto Serif SC
 font.family : serif

--- a/scienceplots/styles/languages/cjk-tc-font.mplstyle
+++ b/scienceplots/styles/languages/cjk-tc-font.mplstyle
@@ -1,5 +1,5 @@
 # Add fonts for CJK characters (traditional Chinese)
 # See FAQ in README for installation instructions
 
-font.serif : Noto Serif CJK TC
+font.serif : Noto Serif TC
 font.family : serif

--- a/scienceplots/tests/test_scienceplots.py
+++ b/scienceplots/tests/test_scienceplots.py
@@ -20,7 +20,7 @@ def test_styles_existence(styles_in_scienceplots_per_folder):
     for folder, styles in styles_in_scienceplots_per_folder.items():
         assert len(styles) > 0, f"No styles found in {folder}."
         for style in styles:
-            assert (  # both in list of names and the library they are retrieved from hello
+            assert (  # both in list of names and the library they are retrieved from
                 style in plt.style.available and style in plt.style.library
             ), f"'{style}' not in available styles. Style in folder {folder}."
 
@@ -42,4 +42,50 @@ def test_usage_of_each_style(
                 ax.set(**pparam)
                 ax.autoscale(tight=True)
                 fig.savefig(output_file)
+                assert output_file.exists(), f"Output file was not created: {output_file}"
+                assert output_file.stat().st_size > 0, f"Output file is empty: {output_file}"
                 plt.close(fig)
+
+
+def test_no_latex_override():
+    """Tests that 'no-latex' style correctly overrides 'text.usetex' from 'science' style."""
+    # Check initial state with 'science' style (should be True)
+    # Ensure 'science' style is in library for this check to be robust
+    # and actually sets 'text.usetex'.
+    # scienceplots/__init__.py ensures styles are loaded before tests run.
+    science_style_params = plt.style.library.get('science', {})
+    science_sets_usetex = science_style_params.get('text.usetex', False)
+
+    if science_sets_usetex:
+        with plt.style.context('science'):
+            assert plt.rcParams['text.usetex'] is True, \
+                "rcParams['text.usetex'] should be True when 'science' style is applied."
+
+    # Test the override
+    # Note: 'science' style is applied first, then 'no-latex' overrides its 'text.usetex'.
+    with plt.style.context(['science', 'no-latex']):
+        assert plt.rcParams['text.usetex'] is False, \
+            "rcParams['text.usetex'] should be False when 'no-latex' is applied after 'science'."
+
+    # Final check: After the context, rcParams should be restored.
+    # If 'science' was the baseline and set usetex True, it should revert to that.
+    # If MPL default for usetex is False, and 'science' was not applied before this test's contexts,
+    # it should revert to False or its original state prior to this test.
+    # This part can be tricky as test order is not guaranteed and rcParams are global.
+    # The main goal is to test the override *within* the specific context.
+    # For robustness, let's check against the known state of 'science' if it was applied.
+    if science_sets_usetex:
+        # This assumes that exiting the context restores to the state *before that context*.
+        # If the outer state was 'science', it should return to text.usetex = True.
+        # If the outer state was default matplotlib, it would be text.usetex = False (usually).
+        # To be absolutely sure, one might need to snapshot rcParams, but that's overkill here.
+        # The critical assertion is the one *inside* the ['science', 'no-latex'] context.
+        # Let's re-apply 'science' to check its state for clarity if it was supposed to be True.
+        with plt.style.context('science'):
+            assert plt.rcParams['text.usetex'] is True, \
+                "rcParams['text.usetex'] should revert to True for 'science' style after other contexts."
+    else:
+        # If 'science' style itself doesn't set 'text.usetex':True (e.g. if science.mplstyle was modified),
+        # then check if it's False (Matplotlib default).
+        assert plt.rcParams['text.usetex'] is plt.style.library['default']['text.usetex'], \
+            "rcParams['text.usetex'] should revert to Matplotlib default if 'science' doesn't set it."


### PR DESCRIPTION
This commit addresses several high and medium priority issues:

Critical & High Priority:
- Fix CJK font style definitions to use common system font names, addressing findfont errors (Issue #84).
- Corrected a typo in a test comment.
- Enhanced style usage tests to verify output file existence and non-zero size, improving test robustness.
- Confirmed OSError in v2.0.0 (Issue #78) is a usage requirement (must import scienceplots first) and is covered by README.

Medium Priority:
- Prepared draft documentation (Python example script and Markdown for Wiki) for the 'discrete-rainbow-*' color style series (Issue #126).
- Added a new test to verify that the 'no-latex' style correctly overrides 'text.usetex' parameter from other styles.
- Enabled Ruff checks for type annotations by default in pyproject.toml to encourage adoption of type hints.
- Clarified comments for the [tool.setuptools_scm] section in pyproject.toml.
- Added 'ruff' to development dependencies under a 'dev' group in pyproject.toml and updated the 'all' group.